### PR TITLE
Add filtering ability to SortableBindingList

### DIFF
--- a/Dinah.Core/DataBinding/SortableBindingList[T].cs
+++ b/Dinah.Core/DataBinding/SortableBindingList[T].cs
@@ -42,11 +42,11 @@ namespace Dinah.Core.DataBinding
 		/// <summary>
 		/// items that were removed from the list due to filtering and their pre-filtering indices
 		/// </summary>
-		private List<(int originalIndex,T item)> filterRemovedIndexed = new List<(int originalIndex, T item)>();
+		private List<(int originalIndex,T item)> filterRemovedIndexed = new();
 		/// <summary>
 		/// Filtered items in the list and their pre-filtering indices.
 		/// </summary>
-		private List<(int originalIndex,T item)> filteredIndexed = new();
+		private List<(int originalIndex,T item)> filteredItemsIndexed = new();
 
 		/// <summary>
 		/// Filters the list
@@ -63,9 +63,7 @@ namespace Dinah.Core.DataBinding
 					base.OnListChanged(new ListChangedEventArgs(ListChangedType.ItemDeleted, i));
 				}
 				else
-				{
-					filteredIndexed.Add((i, InnerList[i]));
-				}
+					filteredItemsIndexed.Add((i, InnerList[i]));
 			}
 		}
 		/// <summary>
@@ -73,7 +71,7 @@ namespace Dinah.Core.DataBinding
 		/// </summary>
 		public void RemoveFilter()
 		{
-			if (filteredIndexed.Count == 0) return;
+			if (filteredItemsIndexed.Count == 0) return;
 
 			for (int i = InnerList.Count - 1; i >= 0; i--)
 			{
@@ -81,7 +79,7 @@ namespace Dinah.Core.DataBinding
 				base.OnListChanged(new ListChangedEventArgs(ListChangedType.ItemDeleted, i));
 			}
 
-			filterRemovedIndexed.AddRange(filteredIndexed);
+			filterRemovedIndexed.AddRange(filteredItemsIndexed);
 
 			if (!IsSortedCore)
 				filterRemovedIndexed.Sort((i1, i2) => i1.originalIndex.CompareTo(i2.originalIndex));
@@ -93,7 +91,7 @@ namespace Dinah.Core.DataBinding
 			}
 
 			filterRemovedIndexed.Clear();
-			filteredIndexed.Clear();
+			filteredItemsIndexed.Clear();
 
 			if (IsSortedCore)
 				Sort();


### PR DESCRIPTION
There are 2 ways you can do filtering in a DataGridView bound to a SortableBindingList

1. Implement IBindingListView in your SortableBindingList. This look like a lot of work and has the drawback of only accepting a string filter, so complex object filtering is not an option unless it's done inside the Dinah.Core library, which I assume you don't want to do.
2. Implement sorting in BindingSource by overriding SupportsFiltering, Filter, and RemoveFilter

I went with #2. Inside Libation, SyncBindingSource performs the filtering based on the search string.  It builds a list of filtered items and passes that list to SortableBindingList.SetFilteredItems.

SetFilteredItems will move all currently-present list items that aren't in the filtered list into a filterRemovedIndexed, and notifies the view that those items have been removed.

When filtering is removed, the items in filterRemovedIndexed are added back to the inner list and the view is notified. Sorting is re-applied.