### PR TITLE
Enable nullable

### DIFF
--- a/Dinah.Core/ArgumentValidator.cs
+++ b/Dinah.Core/ArgumentValidator.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Numerics;
 
+#nullable enable
 namespace Dinah.Core
 {
     public static class ArgumentValidator
@@ -15,7 +18,7 @@ namespace Dinah.Core
         /// <param name="name">The name of the <i>argument</i> that will be used to identify it should an exception be thrown.</param>
         /// <returns>If valid: return argument for convenient assignment</returns>
         /// <exception cref="ArgumentNullException">Thrown when <i>argument</i> is null.</exception>
-        public static T EnsureNotNull<T>(T argument, string name)
+        public static T EnsureNotNull<T>([NotNull] T? argument, string name)
         {
             if (argument == null)
 				throw new ArgumentNullException(name);
@@ -31,7 +34,7 @@ namespace Dinah.Core
         /// <returns>If valid: return argument for convenient assignment</returns>
         /// <exception cref="ArgumentNullException">Thrown when <i>argument</i> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <i>argument</i> is empty.</exception>
-        public static IEnumerable<T> EnsureEnumerableNotNullOrEmpty<T>(IEnumerable<T> argument, string name)
+        public static IEnumerable<T> EnsureEnumerableNotNullOrEmpty<T>([NotNull] IEnumerable<T>? argument, string name)
         {
             EnsureNotNull(argument, name);
             if (!argument.Any())
@@ -47,7 +50,7 @@ namespace Dinah.Core
         /// <returns>If valid: return argument for convenient assignment</returns>
         /// <exception cref="ArgumentNullException">Thrown when <i>argument</i> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <i>argument</i> is an empty string.</exception>
-        public static string EnsureNotNullOrEmpty(string argument, string name)
+        public static string EnsureNotNullOrEmpty([NotNull] string? argument, string name)
         {
             EnsureNotNull(argument, name);
             if (string.IsNullOrEmpty(argument))
@@ -63,7 +66,7 @@ namespace Dinah.Core
         /// <returns>If valid: return argument for convenient assignment</returns>
         /// <exception cref="ArgumentNullException">Thrown when <i>argument</i> is null.</exception>
         /// <exception cref="ArgumentException">Thrown when <i>argument</i> is either an empty string or contains only white space.</exception>
-        public static string EnsureNotNullOrWhiteSpace(string argument, string name)
+        public static string EnsureNotNullOrWhiteSpace([NotNull] string? argument, string name)
         {
             EnsureNotNull(argument, name);
             if (string.IsNullOrWhiteSpace(argument))
@@ -71,38 +74,32 @@ namespace Dinah.Core
             return argument;
         }
 
-        /// <summary>
-        /// Used to verify that the provided argument is greater than the minimum value. Minimum value is not valid. i.e. exclusive
-        /// </summary>
-        /// <param name="argument">argument to check</param>
-        /// <param name="name">Name of the argument</param>
-        /// <param name="minimum">Value argument must be greater than</param>
-        /// <typeparam name="T">Type of the argument. Must be IComparable</typeparam>
-        /// <returns>If valid: return argument for convenient assignment</returns>
-        public static T EnsureGreaterThan<T>(T argument, string name, T minimum) where T : IComparable<T>
+		/// <summary>
+		/// Used to verify that the provided argument is greater than the minimum value. Minimum value is not valid. i.e. exclusive
+		/// </summary>
+		/// <param name="argument">argument to check</param>
+		/// <param name="name">Name of the argument</param>
+		/// <param name="minimum">Value argument must be greater than</param>
+		/// <typeparam name="T">Type of the argument. Must be IComparable struct</typeparam>
+		/// <returns>If valid: return argument for convenient assignment</returns>
+		public static T EnsureGreaterThan<T>(T argument, string name, T minimum) where T : struct, IComparable<T>
         {
-            if (minimum is null)
-                return argument;
-
             if (argument.CompareTo(minimum) <= 0)
 				throw new ArgumentException($"The provided value must be greater than {minimum}. Actual value: {argument}", name);
             return argument;
         }
 
-        /// <summary>
-        /// Used to verify that the provided argument is greater than the minimum value and less than the maximum value. Minimum and maximum values are valid. i.e. inclusive
-        /// </summary>
-        /// <param name="argument">argument to check</param>
-        /// <param name="name">Name of the argument</param>
-        /// <param name="minimum">Value argument must be greater than</param>
-        /// <param name="maximum">Value argument must be less than</param>
-        /// <typeparam name="T">Type of the argument. Must be IComparable</typeparam>
-        /// <returns>If valid: return argument for convenient assignment</returns>
-        public static T EnsureBetweenInclusive<T>(T argument, string name, T minimum, T maximum) where T : IComparable<T>
+		/// <summary>
+		/// Used to verify that the provided argument is greater than the minimum value and less than the maximum value. Minimum and maximum values are valid. i.e. inclusive
+		/// </summary>
+		/// <param name="argument">argument to check</param>
+		/// <param name="name">Name of the argument</param>
+		/// <param name="minimum">Value argument must be greater than</param>
+		/// <param name="maximum">Value argument must be less than</param>
+		/// <typeparam name="T">Type of the argument. Must be IComparable struct</typeparam>
+		/// <returns>If valid: return argument for convenient assignment</returns>
+		public static T EnsureBetweenInclusive<T>(T argument, string name, T minimum, T maximum) where T : struct, IComparable<T>
         {
-            if (minimum is null || maximum is null)
-                return argument;
-
             if (argument.CompareTo(minimum) < 0 || argument.CompareTo(maximum) > 0)
                 throw new ArgumentException($"The provided value must be between {minimum} and {maximum}, inclusive. Actual value: {argument}", name);
             return argument;

--- a/Dinah.Core/ConsoleLib/ProgressBar.cs
+++ b/Dinah.Core/ConsoleLib/ProgressBar.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using System.Threading;
 
+#nullable enable
 namespace Dinah.Core.ConsoleLib
 {
 	// https://stackoverflow.com/a/31193455
@@ -42,7 +43,7 @@ namespace Dinah.Core.ConsoleLib
 			timerHandler(null);
 		}
 
-		private void timerHandler(object state)
+		private void timerHandler(object? state)
 		{
 			lock (timer)
 			{

--- a/Dinah.Core/DataBinding/FilterableSortableBindingList[TE, TSR].cs
+++ b/Dinah.Core/DataBinding/FilterableSortableBindingList[TE, TSR].cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 
+#nullable enable
 namespace Dinah.Core.DataBinding
 {
 	/// <summary>
@@ -23,17 +24,17 @@ namespace Dinah.Core.DataBinding
 	/// <typeparam name="TSearchResults"></typeparam>
 	public class FilterableSortableBindingList<TEntry, TSearchResults> : BindingList<TEntry>, IBindingListView where TEntry : IMemberComparable
 	{
-		public Func<string, TSearchResults> GetSearchResults { get; set; }
-		public Func<TSearchResults, TEntry, bool> SearchResultsContain { get; set; }
+		public Func<string?, TSearchResults>? GetSearchResults { get; set; }
+		public Func<TSearchResults, TEntry, bool>? SearchResultsContain { get; set; }
 
 		/// <summary>
 		/// Items that were removed from the base list due to filtering
 		/// </summary>
 		private readonly List<TEntry> FilterRemoved = new();
-		private string FilterString;
+		private string? FilterString;
 		private bool isSorted;
 		private ListSortDirection listSortDirection;
-		private PropertyDescriptor propertyDescriptor;
+		private PropertyDescriptor? propertyDescriptor;
 		private readonly string DefaultSortProperty;
 		private readonly ListSortDirection DefaultSearchDirection;
 
@@ -50,13 +51,13 @@ namespace Dinah.Core.DataBinding
 		protected override bool SupportsSortingCore => true;
 		protected override bool SupportsSearchingCore => true;
 		protected override bool IsSortedCore => isSorted;
-		protected override PropertyDescriptor SortPropertyCore => propertyDescriptor;
+		protected override PropertyDescriptor? SortPropertyCore => propertyDescriptor;
 		protected override ListSortDirection SortDirectionCore => listSortDirection;
 
 		/// <returns>All items in the list, including those filtered out.</returns>
 		public List<TEntry> AllItems() => Items.Concat(FilterRemoved).ToList();
 		public bool SupportsFiltering => true;
-		public string Filter { get => FilterString; set => ApplyFilter(value); }
+		public string? Filter { get => FilterString; set => ApplyFilter(value); }
 
 		#region Unused - Advanced Filtering
 		public bool SupportsAdvancedSorting => false;
@@ -92,9 +93,9 @@ namespace Dinah.Core.DataBinding
 			itemsList.AddRange(sortedItems);
 		}
 
-		private void ApplyFilter(string filterString)
+		private void ApplyFilter(string? filterString)
 		{
-			if (SearchResultsContain is null || SearchResultsContain is null)
+			if (SearchResultsContain is null || GetSearchResults is null)
 				throw new NotSupportedException($"{nameof(GetSearchResults)} and {nameof(SearchResultsContain)} must be set before filtering.");
 
 			if (filterString != FilterString)
@@ -157,7 +158,7 @@ namespace Dinah.Core.DataBinding
 		{
 			int count = Count;
 
-			System.Collections.IComparer valueComparer = null;
+			System.Collections.IComparer? valueComparer = null;
 
 			for (int i = 0; i < count; ++i)
 			{

--- a/Dinah.Core/DataBinding/MemberComparer.cs
+++ b/Dinah.Core/DataBinding/MemberComparer.cs
@@ -1,17 +1,25 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel;
 
+#nullable enable
 namespace Dinah.Core.DataBinding
 {
 	public class MemberComparer<T> : IComparer<T> where T : IMemberComparable
 	{
 		public ListSortDirection Direction { get; set; } = ListSortDirection.Ascending;
-		public string PropertyName { get; set; }
+		public string? PropertyName { get; set; }
 
-		public int Compare(T x, T y)
+		public int Compare(T? x, T? y)
 		{
-			var val1 = x.GetMemberValue(PropertyName);
-			var val2 = y.GetMemberValue(PropertyName);
+			if (x is null && y is null) return 0;
+			if (x is null && y is not null) return -1;
+			if (x is not null && y is null) return 1;
+
+			if (PropertyName is null)
+				throw new NullReferenceException(nameof(PropertyName));
+
+			var val1 = x!.GetMemberValue(PropertyName);
+			var val2 = y!.GetMemberValue(PropertyName);
 
 			return DirMult * x.GetMemberComparer(val1.GetType()).Compare(val1, val2);
 		}

--- a/Dinah.Core/DataBinding/SortableBindingList[T].cs
+++ b/Dinah.Core/DataBinding/SortableBindingList[T].cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
 
+#nullable enable
 namespace Dinah.Core.DataBinding
 {
 	// see also notes in Libation/Source/_ARCHITECTURE NOTES.txt :: MVVM
@@ -10,16 +11,16 @@ namespace Dinah.Core.DataBinding
 	{
 		private bool isSorted;
 		private ListSortDirection listSortDirection;
-		private PropertyDescriptor propertyDescriptor;
+		private PropertyDescriptor? propertyDescriptor;
 
-		public SortableBindingList() : base(new List<T>()) { }
+		public SortableBindingList() { }
 		public SortableBindingList(IEnumerable<T> enumeration) : base(new List<T>(enumeration)) { }
 
 		private MemberComparer<T> Comparer { get; } = new();
 		protected override bool SupportsSortingCore => true;
 		protected override bool SupportsSearchingCore => true;
 		protected override bool IsSortedCore => isSorted;
-		protected override PropertyDescriptor SortPropertyCore => propertyDescriptor;
+		protected override PropertyDescriptor? SortPropertyCore => propertyDescriptor;
 		protected override ListSortDirection SortDirectionCore => listSortDirection;
 
 		protected override void ApplySortCore(PropertyDescriptor property, ListSortDirection direction)
@@ -76,7 +77,7 @@ namespace Dinah.Core.DataBinding
 		{
 			int count = Count;
 
-			System.Collections.IComparer valueComparer = null;
+			System.Collections.IComparer? valueComparer = null;
 
 			for (int i = 0; i < count; ++i)
 			{

--- a/Dinah.Core/Enumeration.cs
+++ b/Dinah.Core/Enumeration.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
+#nullable enable
 // FROM
 // https://lostechies.com/jimmybogard/2008/08/12/enumeration-classes/
 // tarantino / src / Tarantino.DatabaseManager.Core / Enumeration.cs
@@ -49,7 +50,7 @@ namespace Dinah.Core
 				cache.Add(t, properties.Concat(fields));
 			}
 
-			return cache[t] as IEnumerable<T>;
+			return (IEnumerable<T>)cache[t];
 		}
 
 		//public static IEnumerable GetAll(Type type)
@@ -59,7 +60,7 @@ namespace Dinah.Core
 		//        yield return info.GetValue(Activator.CreateInstance(type));
 		//}
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 		{
 			if (!(obj is Enumeration otherValue))
 				return false;
@@ -84,6 +85,6 @@ namespace Dinah.Core
 			=> GetAll<T>().FirstOrDefault(predicate)
 			?? throw new ApplicationException($"'{value}' is not a valid {description} in {typeof(T)}");
 
-		public virtual int CompareTo(object obj) => Value.CompareTo(((Enumeration)obj).Value);
+		public virtual int CompareTo(object? obj) => Value.CompareTo((obj as Enumeration)?.Value);
 	}
 }

--- a/Dinah.Core/Go.To.cs
+++ b/Dinah.Core/Go.To.cs
@@ -56,7 +56,7 @@ namespace Dinah.Core
                     return true;
                 }
 
-                return Folder(System.IO.Path.GetDirectoryName(path));
+				return System.IO.Path.GetDirectoryName(path) is string dir && Folder(dir);
             }
 
             /// <summary>Platform agnostic. Open folder</summary>
@@ -83,8 +83,8 @@ namespace Dinah.Core
                     Arguments = path is null ? string.Empty : $"\"{path}\"",
                     UseShellExecute = false,
                 });
-                proc.WaitForExit();
-                return proc.ExitCode == 0;
+                proc?.WaitForExit();
+                return proc?.ExitCode == 0;
             }
         }
     }

--- a/Dinah.Core/HtmlHelper.cs
+++ b/Dinah.Core/HtmlHelper.cs
@@ -3,16 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using HtmlAgilityPack;
 
+#nullable enable
 namespace Dinah.Core
 {
 	public static class HtmlHelper
 	{
-		public static Dictionary<string, string> GetInputs(string body)
+		public static Dictionary<string, string?> GetInputs(string body)
 		{
 			// ONLY check for null body, not blank or whitespace
 			ArgumentValidator.EnsureNotNull(body, nameof(body));
 
-			var inputs = new Dictionary<string, string>();
+			var inputs = new Dictionary<string, string?>();
 
 			var doc = new HtmlDocument();
 			doc.LoadHtml(body);
@@ -34,15 +35,16 @@ namespace Dinah.Core
 			return inputs;
 		}
 
-		public static List<string> GetLinks(string body, string className = null)
+		public static List<string> GetLinks(string body, string? className = null)
 			=> GetElements(body, "a", "class", className)
 			.Select(node => node.Attributes["href"]?.Value)
+			.OfType<string>()
 			.Where(href => !string.IsNullOrWhiteSpace(href))
 			.ToList();
 
-		public static int GetDivCount(string body, string id = null) => GetElements(body, "div", "id", id).Count;
+		public static int GetDivCount(string body, string? id = null) => GetElements(body, "div", "id", id).Count;
 
-		public static List<HtmlNode> GetElements(string body, string tag, string attribName = null, string attribValue = null)
+		public static List<HtmlNode> GetElements(string body, string tag, string? attribName = null, string? attribValue = null)
 		{
 			// ONLY check for null body, not blank or whitespace
 			ArgumentValidator.EnsureNotNull(body, nameof(body));

--- a/Dinah.Core/InterruptableTimer.cs
+++ b/Dinah.Core/InterruptableTimer.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 
+#nullable enable
 namespace Dinah.Core
 {
     public class InterruptableTimer
     {
-        public event EventHandler Elapsed;
+        public event EventHandler? Elapsed;
 
         private System.Timers.Timer _timer;
 
@@ -19,7 +20,9 @@ namespace Dinah.Core
         /// <para>If timer is not running: invoke event, then begin waiting.</para>
         /// <para>If timer is running: stop timer (ie: do not wait for interval to complete. aka: interrupt), invoke event then, re-start waiting.</para>
         /// </summary>
-        public void PerformNow(object _ = null, EventArgs __ = null)
+        public void PerformNow() => PerformNow(null, EventArgs.Empty);
+
+		public void PerformNow(object? _, EventArgs __)
         {
             Stop();
             Elapsed?.Invoke(_, __);

--- a/Dinah.Core/Logging/SerilogEnricher.cs
+++ b/Dinah.Core/Logging/SerilogEnricher.cs
@@ -27,7 +27,7 @@ namespace Dinah.Core.Logging
 				}
 
 				var method = stack.GetMethod();
-				if (method.DeclaringType != null && method.DeclaringType.Assembly != typeof(Log).Assembly)
+				if (method?.DeclaringType != null && method.DeclaringType.Assembly != typeof(Log).Assembly)
 				{
 					var caller = $"{method.DeclaringType.FullName}.{method.Name}({string.Join(", ", method.GetParameters().Select(pi => pi.ParameterType.FullName))})";
 					logEvent.AddPropertyIfAbsent(new LogEventProperty("Caller", new ScalarValue(caller)));

--- a/Dinah.Core/ObjectExtensions.cs
+++ b/Dinah.Core/ObjectExtensions.cs
@@ -4,11 +4,12 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
+#nullable enable
 namespace Dinah.Core
 {
 	public static class ObjectExtensions
 	{
-		public static string GetDescription<T>(this T e)
+		public static string? GetDescription<T>(this T e)
 		{
 			// identical
 			//en.GetType().IsDefined(typeof(FlagsAttribute), false)
@@ -26,18 +27,20 @@ namespace Dinah.Core
 			return e.getDescription();
 		}
 
-		private static string getFlagDescriptions(this Enum en)
+		private static string? getFlagDescriptions(this Enum en)
 			=> Enum.GetValues(en.GetType()).Cast<Enum>()
 				.Where(enumValue => en.HasFlag(enumValue) && Convert.ToInt64(enumValue) > 0)
 				.Select(enumValue => enumValue.getDescription())
 				.Aggregate((a, b) => $"{a ?? "[null]"} | {b ?? "[null]"}");
 
-		private static string getDescription<T>(this T e)
+		private static string? getDescription<T>(this T e)
 		{
+			if (e?.ToString() is not string stringVal) return null;
+
 			var attribute =
 				e.GetType()
 				.GetTypeInfo()
-				.GetMember(e.ToString())
+				.GetMember(stringVal)
 				.FirstOrDefault(member => member.MemberType == MemberTypes.Field)
 				?.GetCustomAttributes(typeof(DescriptionAttribute), false)
 				.SingleOrDefault()

--- a/Dinah.Core/PropertyChangeFilter.cs
+++ b/Dinah.Core/PropertyChangeFilter.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 
+#nullable enable
 namespace Dinah.Core
 {
 	#region Useage
@@ -81,7 +82,7 @@ namespace Dinah.Core
 		private readonly List<(PropertyChangedEventHandlerEx subscriber, PropertyChangedEventHandlerEx wrapper)> changedFilters = new();
 		private readonly List<(PropertyChangingEventHandlerEx subscriber, PropertyChangingEventHandlerEx wrapper)> changingFilters = new();
 
-		protected void OnPropertyChanged(string propertyName, object newValue)
+		protected void OnPropertyChanged(string propertyName, object? newValue)
 		{
 			if (propertyChangedActions.ContainsKey(propertyName))
 			{
@@ -93,7 +94,7 @@ namespace Dinah.Core
 			_propertyChanged?.Invoke(this, new(propertyName, newValue));
 		}
 
-		protected void OnPropertyChanging(string propertyName, object oldValue, object newValue)
+		protected void OnPropertyChanging(string propertyName, object? oldValue, object? newValue)
 		{
 			if (propertyChangingActions.ContainsKey(propertyName))
 			{
@@ -107,8 +108,8 @@ namespace Dinah.Core
 
 		#region Events
 
-		private PropertyChangedEventHandlerEx _propertyChanged;
-		private PropertyChangingEventHandlerEx _propertyChanging;
+		private PropertyChangedEventHandlerEx? _propertyChanged;
+		private PropertyChangingEventHandlerEx? _propertyChanging;
 
 		public event PropertyChangedEventHandlerEx PropertyChanged
 		{
@@ -182,7 +183,7 @@ namespace Dinah.Core
 		}
 
 		private static T[] getAttributes<T>(MethodInfo methodInfo) where T : Attribute
-			=> Attribute.GetCustomAttributes(methodInfo, typeof(T)) as T[];
+			=> (T[])Attribute.GetCustomAttributes(methodInfo, typeof(T));
 
 		#endregion
 
@@ -292,9 +293,9 @@ namespace Dinah.Core
 
 	public class PropertyChangedEventArgsEx : PropertyChangedEventArgs
 	{
-		public object NewValue { get; }
+		public object? NewValue { get; }
 
-		public PropertyChangedEventArgsEx(string propertyName, object newValue) : base(propertyName)
+		public PropertyChangedEventArgsEx(string propertyName, object? newValue) : base(propertyName)
 		{
 			NewValue = newValue;
 		}
@@ -302,10 +303,10 @@ namespace Dinah.Core
 
 	public class PropertyChangingEventArgsEx : PropertyChangingEventArgs
 	{
-		public object OldValue { get; }
-		public object NewValue { get; }
+		public object? OldValue { get; }
+		public object? NewValue { get; }
 
-		public PropertyChangingEventArgsEx(string propertyName, object oldValue, object newValue) : base(propertyName)
+		public PropertyChangingEventArgsEx(string propertyName, object? oldValue, object? newValue) : base(propertyName)
 		{
 			OldValue = oldValue;
 			NewValue = newValue;

--- a/Dinah.Core/StepRunner/Abstract_AsyncBaseStep.cs
+++ b/Dinah.Core/StepRunner/Abstract_AsyncBaseStep.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
+#nullable enable
 namespace Dinah.Core.StepRunner
 {
 	public abstract class AsyncBaseStep : BaseStep
@@ -14,7 +15,7 @@ namespace Dinah.Core.StepRunner
 			var stopwatch = Stopwatch.StartNew();
 
 			bool success;
-			Exception exc = null;
+			Exception? exc = null;
 			try
 			{
 				success = await RunRawAsync();

--- a/Dinah.Core/StepRunner/Abstract_BaseStep.cs
+++ b/Dinah.Core/StepRunner/Abstract_BaseStep.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Diagnostics;
 
+#nullable enable
 namespace Dinah.Core.StepRunner
 {
     public abstract class BaseStep
     {
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         protected abstract bool RunRaw();
 
@@ -16,7 +17,7 @@ namespace Dinah.Core.StepRunner
 			var stopwatch = Stopwatch.StartNew();
 
 			bool success;
-			Exception exc = null;
+			Exception? exc = null;
 			try
 			{
 				success = RunRaw();
@@ -40,7 +41,7 @@ namespace Dinah.Core.StepRunner
 			Serilog.Log.Logger.Information($"Begin step '{Name}'");
 		}
 
-		protected void logEnd(bool success, TimeSpan elapsed, Exception exc)
+		protected void logEnd(bool success, TimeSpan elapsed, Exception? exc)
 		{
 			var logStart = $"End step '{Name}'. ";
 			var logEnd = $". Completed in {elapsed.GetTotalTimeFormatted()}";

--- a/Dinah.Core/StepRunner/AsyncBasicStep.cs
+++ b/Dinah.Core/StepRunner/AsyncBasicStep.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Linq;
 
+#nullable enable
 namespace Dinah.Core.StepRunner
 {
 	public class AsyncBasicStep : AsyncBaseStep
 	{
-		public Func<Task<bool>> FnT { get; set; }
-		protected override async Task<bool> RunRawAsync() => await FnT();
+		public Func<Task<bool>>? FnT { get; set; }
+		protected override async Task<bool> RunRawAsync() => FnT is not null && await FnT();
 	}
 }

--- a/Dinah.Core/StepRunner/BasicStep.cs
+++ b/Dinah.Core/StepRunner/BasicStep.cs
@@ -2,11 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
 namespace Dinah.Core.StepRunner
 {
     public class BasicStep : BaseStep
     {
-        public Func<bool> Fn { get; set; }
-        protected override bool RunRaw() => Fn();
+        public Func<bool>? Fn { get; set; }
+        protected override bool RunRaw() => Fn is not null && Fn();
     }
 }

--- a/Dinah.Core/StringExtensions.cs
+++ b/Dinah.Core/StringExtensions.cs
@@ -1,14 +1,16 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
+#nullable enable
 namespace Dinah.Core
 {
 	public static class StringExtensions
 	{
-		public static bool EqualsInsensitive(this string str1, string str2) => string.Equals(str1, str2, StringComparison.OrdinalIgnoreCase);
+		public static bool EqualsInsensitive(this string? str1, string? str2) => string.Equals(str1, str2, StringComparison.OrdinalIgnoreCase);
 
 		public static bool StartsWithInsensitive(this string str1, string str2) => str1.StartsWith(str2, StringComparison.OrdinalIgnoreCase);
 
@@ -21,7 +23,8 @@ namespace Dinah.Core
 		/// <summary>return qty and noun</summary>
 		public static string PluralizeWithCount(this string str, int qty) => new Pluralize.NET.Pluralizer().Format(str, qty, true);
 
-		public static string FirstCharToUpper(this string str)
+		[return: NotNullIfNotNull(nameof(str))]
+		public static string? FirstCharToUpper(this string? str)
 		{
 			if (string.IsNullOrWhiteSpace(str))
 				return str;
@@ -32,7 +35,8 @@ namespace Dinah.Core
 			return char.ToUpper(str[0]) + str.Substring(1);
 		}
 
-		public static string Truncate(this string str, int limit)
+		[return: NotNullIfNotNull(nameof(str))]
+		public static string? Truncate(this string? str, int limit)
 			=> str is null ? null
 			: str.Length.In(0, 1) ? str
 			: limit < 1 ? str.Substring(0, 1)
@@ -41,7 +45,8 @@ namespace Dinah.Core
 
 		public static string SurroundWithQuotes(this string str) => "\"" + str + "\"";
 
-		public static string ExtractString(this string haystack, string before, int needleLength)
+
+		public static string? ExtractString(this string? haystack, string? before, int needleLength)
 		{
 			if (string.IsNullOrWhiteSpace(haystack))
 				return null;
@@ -65,7 +70,7 @@ namespace Dinah.Core
 		}
 
 		/// <summary>A very forgiving interpretation of a string to a boolean.</summary>
-		public static bool ToBoolean(this string str)
+		public static bool ToBoolean(this string? str)
 			=> str is null ? false : str.Trim().ToLower(CultureInfo.InvariantCulture).In("y", "1", "t", "true");
 
 		private const string _validHexChars = "0123456789ABCDEFabcdef";
@@ -78,7 +83,7 @@ namespace Dinah.Core
 		///   If the string contains non-hexadecimal characters (except for leading or trailing white space, which is ignored), or if it 
 		///   does not contain an even number of characters (since 2 characters are needed to represent each byte).
 		/// </exception>
-		public static byte[] HexStringToByteArray(this string hexValue)
+		public static byte[] HexStringToByteArray([NotNull] this string? hexValue)
 		{
 			hexValue = hexValue?.Trim();
 
@@ -210,10 +215,10 @@ namespace Dinah.Core
 			return output;
 		}
 
-		public static string DefaultIfNullOrWhiteSpace(this string value, string defaultValue)
+		public static string DefaultIfNullOrWhiteSpace(this string? value, string defaultValue)
 			=> string.IsNullOrWhiteSpace(value) ? defaultValue : value;
 		
-		public static string DefaultIfNullOrEmpty(this string value, string defaultValue)
+		public static string DefaultIfNullOrEmpty(this string? value, string defaultValue)
 			=> string.IsNullOrEmpty(value) ? defaultValue : value;
 
 		/// <summary>

--- a/Dinah.Core/StringLib.cs
+++ b/Dinah.Core/StringLib.cs
@@ -1,11 +1,14 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
 
+#nullable enable
 namespace Dinah.Core
 {
 	public static class StringLib
 	{
-		public static string ToBase64(string text)
+		[return: NotNullIfNotNull(nameof(text))]
+		public static string? ToBase64(string? text)
 		{
 			if (string.IsNullOrEmpty(text))
 				return text;
@@ -13,7 +16,8 @@ namespace Dinah.Core
 			return Convert.ToBase64String(textBytes);
 		}
 
-		public static string FromBase64(string base64EncodedText)
+		[return: NotNullIfNotNull(nameof(base64EncodedText))]
+		public static string? FromBase64(string? base64EncodedText)
 		{
 			if (string.IsNullOrEmpty(base64EncodedText))
 				return base64EncodedText;
@@ -22,7 +26,7 @@ namespace Dinah.Core
 		}
 
 		private static Regex regex { get; } = new Regex(@"(?<index>-?\d+\.?\d*)", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
-		public static float ExtractFirstNumber(string text)
+		public static float ExtractFirstNumber(string? text)
 			=> string.IsNullOrWhiteSpace(text) || !regex.IsMatch(text) || !float.TryParse(regex.Match(text).Groups["index"].ToString(), out var f)
 			? 0
 			: f;

--- a/Dinah.Core/StrongType[T].cs
+++ b/Dinah.Core/StrongType[T].cs
@@ -1,4 +1,5 @@
-﻿namespace Dinah.Core
+﻿#nullable enable
+namespace Dinah.Core
 {
 	/// <summary>
 	/// This makes writing code cumbersome ...it's all just strings afterall.
@@ -24,11 +25,11 @@
 			Value = value;
 		}
 
-		protected virtual void ValidateInput(T value) { }
+		protected virtual void ValidateInput(T? value) { }
 
-		public override string ToString() => Value?.ToString();
+		public override string? ToString() => Value?.ToString();
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 			=> (obj is StrongType<T> st) ? Equals(st.Value)
 			: (Value == null) ? (obj is null)
 			: Value.Equals(obj);

--- a/Dinah.Core/SystemExtensions.cs
+++ b/Dinah.Core/SystemExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
+#nullable enable
 namespace Dinah.Core
 {
 	public static class SystemExtensions
@@ -10,7 +12,8 @@ namespace Dinah.Core
 		public static string ToRfc3339String(this DateTime dateTime)
 			=> System.Xml.XmlConvert.ToString(dateTime, System.Xml.XmlDateTimeSerializationMode.Utc);
 
-		public static string GetOrigin(this Uri uri)
-			=> uri.GetLeftPart(UriPartial.Authority);
+		[return: NotNullIfNotNull(nameof(uri))]
+		public static string? GetOrigin(this Uri? uri)
+			=> uri?.GetLeftPart(UriPartial.Authority);
 	}
 }

--- a/Dinah.Core/TypeExtensions.cs
+++ b/Dinah.Core/TypeExtensions.cs
@@ -1,22 +1,26 @@
 ﻿using System;
 
+#nullable enable
 namespace Dinah.Core
 {
     public static class TypeExtensions
     {
-        public static bool IsGenericOf(this Type toCheck, Type generic)
+        public static bool IsGenericOf(this Type type, Type? generic)
         {
             if (generic is null)
                 return false;
 
             var objType = typeof(object);
-            while (toCheck != null && toCheck != objType)
+
+            Type? toCheck = type;
+
+			while (toCheck != null && toCheck != objType)
             {
                 var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
                 if (generic == cur)
                     return true;
 
-                toCheck = toCheck.BaseType;
+				toCheck = toCheck.BaseType;
             }
             return false;
         }

--- a/Dinah.Core/ValueObject.cs
+++ b/Dinah.Core/ValueObject.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
 namespace Dinah.Core
 {
 	// https://enterprisecraftsmanship.com/2017/08/28/value-object-a-better-implementation/
@@ -8,28 +9,24 @@ namespace Dinah.Core
 	{
 		protected abstract IEnumerable<object> GetEqualityComponents();
 
-		public override bool Equals(object obj)
+		public override bool Equals(object? obj)
 			=> (obj == null || GetType() != obj.GetType())
 			? false
 			: GetEqualityComponents().SequenceEqual(((ValueObject)obj).GetEqualityComponents());
 
 		public override int GetHashCode()
 		{
-			return GetEqualityComponents()
-				.Aggregate(1, (current, obj) =>
-				{
-					unchecked
-					{
-						return current * 23 + (obj?.GetHashCode() ?? 0);
-					}
-				});
+			HashCode hash = default;
+			foreach (var component in GetEqualityComponents())
+				hash.Add(component);
+			return hash.ToHashCode();
 		}
 
-		public static bool operator ==(ValueObject a, ValueObject b)
+		public static bool operator ==(ValueObject? a, ValueObject? b)
 			=> (a is null && b is null) ? true
 			: (a is null || b is null) ? false
 			: a.Equals(b);
 
-		public static bool operator !=(ValueObject a, ValueObject b) => !(a == b);
+		public static bool operator !=(ValueObject? a, ValueObject? b) => !(a == b);
 	}
 }

--- a/Dinah.Core/_Collections/Generic/IEnumerable[T]Ext.cs
+++ b/Dinah.Core/_Collections/Generic/IEnumerable[T]Ext.cs
@@ -33,7 +33,7 @@ namespace Dinah.Core.Collections.Generic
         /// <returns>
         /// A System.Collections.Generic.Dictionary`2 that contains keys and values. The values within each group are in the same order as in source. Key conflicts are safely avoided.
         /// </returns>
-        public static Dictionary<TKey, TSource> ToDictionarySafe<TKey, TSource>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, WinnerEnum winner = WinnerEnum.FirstInWins)
+        public static Dictionary<TKey, TSource> ToDictionarySafe<TKey, TSource>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, WinnerEnum winner = WinnerEnum.FirstInWins) where TKey : notnull
         {
             var dic = new Dictionary<TKey, TSource>();
 

--- a/Dinah.Core/_IO/FileLogger.cs
+++ b/Dinah.Core/_IO/FileLogger.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 
+#nullable enable
 namespace Dinah.Core.IO
 {
     public class FileLogger
@@ -18,7 +19,7 @@ namespace Dinah.Core.IO
 
         // use with Console.WriteLine
         private object fileLocker { get; } = new object();
-        public void TextWriterLogger(string text)
+        public void TextWriterLogger(string? text)
         {
 			lock (fileLocker)
 			{

--- a/Dinah.Core/_IO/FileLoggerTextWriter.cs
+++ b/Dinah.Core/_IO/FileLoggerTextWriter.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 
+#nullable enable
 namespace Dinah.Core.IO
 {
     public class FileLoggerTextWriter : TextWriter
@@ -10,9 +11,9 @@ namespace Dinah.Core.IO
 
         public FileLoggerTextWriter(FileLogger logger1) => this.logger1 = logger1;
 
-        public override void WriteLine(string value) => logger1.TextWriterLogger(value);
+        public override void WriteLine(string? value) => logger1.TextWriterLogger(value);
         public override void Write(char value) => logger1.TextWriterLogger(value.ToString());
-        public override void Write(string value) => logger1.TextWriterLogger(value);
+        public override void Write(string? value) => logger1.TextWriterLogger(value);
         public override Encoding Encoding => Encoding.ASCII;
     }
 }

--- a/Dinah.Core/_IO/JsonFilePersister.cs
+++ b/Dinah.Core/_IO/JsonFilePersister.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
+#nullable enable
 namespace Dinah.Core.IO
 {
 	/// <summary>
@@ -32,10 +33,10 @@ namespace Dinah.Core.IO
 	{
 		public T Target { get; }
 		public string Path { get; }
-		public string JsonPath { get; }
+		public string? JsonPath { get; }
 
 		/// <summary>uses path. create file if doesn't yet exist</summary>
-		protected JsonFilePersister(T target, string path, string jsonPath = null)
+		protected JsonFilePersister(T target, string path, string? jsonPath = null)
 		{
 			Target = target ?? throw new ArgumentNullException(nameof(target));
 			Target.Updated += saveFile;
@@ -47,11 +48,11 @@ namespace Dinah.Core.IO
 			if (!string.IsNullOrWhiteSpace(jsonPath))
 				JsonPath = jsonPath.Trim();
 
-			saveFile(this, null);
+			saveFile(this, EventArgs.Empty);
 		}
 
 		/// <summary>load from existing file</summary>
-		protected JsonFilePersister(string path, string jsonPath = null)
+		protected JsonFilePersister(string path, string? jsonPath = null)
 		{
 			validatePath(path);
 
@@ -75,7 +76,7 @@ namespace Dinah.Core.IO
 			return target;
 		}
 
-		protected virtual JsonSerializerSettings GetSerializerSettings() => null;
+		protected virtual JsonSerializerSettings? GetSerializerSettings() => null;
 
 		private void validatePath(string path)
 		{
@@ -96,7 +97,7 @@ namespace Dinah.Core.IO
 		{
 			IsInTransaction = false;
 			if (pendingUpdate)
-				saveFile(this, null);
+				saveFile(this, EventArgs.Empty);
 			pendingUpdate = false;
 		}
 
@@ -110,7 +111,7 @@ namespace Dinah.Core.IO
 		protected virtual void OnSaved() { }
 
 		private object _locker { get; } = new object();
-		private void saveFile(object _, EventArgs __)
+		private void saveFile(object? _, EventArgs __)
 		{
 			if (IsInTransaction)
 			{

--- a/Dinah.Core/_IO/MultiTextWriter.cs
+++ b/Dinah.Core/_IO/MultiTextWriter.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 
+#nullable enable
 namespace Dinah.Core.IO
 {
     // from: https://stackoverflow.com/a/18727100
@@ -13,7 +14,7 @@ namespace Dinah.Core.IO
         //public MultiTextWriter(IEnumerable<TextWriter> writers) => this.writers = writers.ToList();
         public MultiTextWriter(params TextWriter[] writers) => this.writers = writers;
 
-        public override void WriteLine(string value)
+        public override void WriteLine(string? value)
         {
             foreach (var writer in writers)
                 writer.WriteLine(value);
@@ -25,7 +26,7 @@ namespace Dinah.Core.IO
                 writer.Write(value);
         }
 
-        public override void Write(string value)
+        public override void Write(string? value)
         {
             foreach (var writer in writers)
                 writer.Write(value);

--- a/Dinah.Core/_IO/SerilogTextWriter.cs
+++ b/Dinah.Core/_IO/SerilogTextWriter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace Dinah.Core.IO
 {
 	public class SerilogTextWriter : TextWriter
@@ -13,7 +14,7 @@ namespace Dinah.Core.IO
 
 		public override void WriteLine() => Serilog.Log.Logger.Information("");
 
-		public override void WriteLine(string value) => Serilog.Log.Logger.Information(value);
+		public override void WriteLine(string? value) => Serilog.Log.Logger.Information(value);
 		public override void WriteLine(bool value) => Serilog.Log.Logger.Information($"{value}");
 		public override void WriteLine(char value) => Serilog.Log.Logger.Information($"{value}");
 		public override void WriteLine(decimal value) => Serilog.Log.Logger.Information($"{value}");
@@ -23,14 +24,14 @@ namespace Dinah.Core.IO
 		public override void WriteLine(long value) => Serilog.Log.Logger.Information($"{value}");
 		public override void WriteLine(ulong value) => Serilog.Log.Logger.Information($"{value}");
 		public override void WriteLine(uint value) => Serilog.Log.Logger.Information($"{value}");
-		public override void WriteLine(StringBuilder value) => Serilog.Log.Logger.Information($"{value}");
+		public override void WriteLine(StringBuilder? value) => Serilog.Log.Logger.Information($"{value}");
 
-		public override void WriteLine(string format, object arg0) => Serilog.Log.Logger.Information(format, arg0);
-		public override void WriteLine(string format, object arg0, object arg1) => Serilog.Log.Logger.Information(format, arg0, arg1);
-		public override void WriteLine(string format, object arg0, object arg1, object arg2) => Serilog.Log.Logger.Information(format, arg0, arg1, arg2);
-		public override void WriteLine(string format, params object[] arg) => Serilog.Log.Logger.Information(format, arg);
+		public override void WriteLine(string format, object? arg0) => Serilog.Log.Logger.Information(format, arg0);
+		public override void WriteLine(string format, object? arg0, object? arg1) => Serilog.Log.Logger.Information(format, arg0, arg1);
+		public override void WriteLine(string format, object? arg0, object? arg1, object? arg2) => Serilog.Log.Logger.Information(format, arg0, arg1, arg2);
+		public override void WriteLine(string format, params object?[] arg) => Serilog.Log.Logger.Information(format, arg);
 
-		public override void WriteLine(object value) => Serilog.Log.Logger.Information("{@DebugInfo}", value);
+		public override void WriteLine(object? value) => Serilog.Log.Logger.Information("{@DebugInfo}", value);
 
 		//
 		//// with stack tracing, the 'Write's should be able to handle this correctly.

--- a/Dinah.Core/_Net/SystemNetExtensions.cs
+++ b/Dinah.Core/_Net/SystemNetExtensions.cs
@@ -1,17 +1,17 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Reflection;
 
+#nullable enable
 namespace Dinah.Core.Net
 {
 	public static class SystemNetExtensions
 	{
 		public static IEnumerable<Cookie> EnumerateCookies(this CookieContainer cookieJar, Uri uri) => cookieJar.GetCookies(uri).Cast<Cookie>();
 
-		public static string Debug_GetCookies(this CookieContainer cookieJar, Uri uri)
+		public static string? Debug_GetCookies(this CookieContainer cookieJar, Uri uri)
 			=> cookieJar
 			.EnumerateCookies(uri)
 			?.ToList()
@@ -20,14 +20,14 @@ namespace Dinah.Core.Net
 			.Trim(';');
 
 		// https://stackoverflow.com/a/14074200
-		public static Hashtable ReflectOverAllCookies(this CookieContainer cookies)
-			=> (Hashtable)cookies.GetType().InvokeMember(
+		public static Hashtable? ReflectOverAllCookies(this CookieContainer cookies)
+			=> cookies.GetType().InvokeMember(
 				"m_domainTable",
 				BindingFlags.NonPublic |
 				BindingFlags.GetField |
 				BindingFlags.Instance,
 				null,
 				cookies,
-				new object[] { });
+				new object[] { }) as Hashtable;
 	}
 }

--- a/Dinah.Core/_Net/_Http/IHttpClient.cs
+++ b/Dinah.Core/_Net/_Http/IHttpClient.cs
@@ -2,13 +2,14 @@
 using System.Net;
 using System.Net.Http.Headers;
 
+#nullable enable
 namespace Dinah.Core.Net.Http
 {
 	public interface IHttpClient : IHttpClientActions
 	{
 		CookieContainer CookieJar { get; }
 		HttpRequestHeaders DefaultRequestHeaders { get; }
-		Uri BaseAddress { get; set; }
+		Uri? BaseAddress { get; set; }
 		long MaxResponseContentBufferSize { get; set; }
 		TimeSpan Timeout { get; set; }
 	}

--- a/_Tests/Dinah.Core.Tests/ArgumentValidatorTests.cs
+++ b/_Tests/Dinah.Core.Tests/ArgumentValidatorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Dinah.Core;
@@ -88,8 +89,6 @@ namespace ArgumentValidatorTests
 	[TestClass]
 	public class EnsureGreaterThan
 	{
-		[TestMethod]
-		public void null_argument_throws() => Assert.ThrowsException<NullReferenceException>(() => ArgumentValidator.EnsureGreaterThan(null, "n", "foo"));
 
 		[TestMethod]
 		public void too_small_throws() => Assert.ThrowsException<ArgumentException>(() => ArgumentValidator.EnsureGreaterThan(9, "n", 10));
@@ -99,17 +98,11 @@ namespace ArgumentValidatorTests
 
 		[TestMethod]
 		public void bigger_passes() => ArgumentValidator.EnsureGreaterThan(9, "n", 8);
-
-		[TestMethod]
-		public void null_minimum_passes() => ArgumentValidator.EnsureGreaterThan("arg", "n", null);
 	}
 
 	[TestClass]
 	public class EnsureBetweenInclusive
 	{
-		[TestMethod]
-		public void null_argument_throws() => Assert.ThrowsException<NullReferenceException>(() => ArgumentValidator.EnsureBetweenInclusive(null, "n", "min", "max"));
-
 		[TestMethod]
 		public void too_small_throws() => Assert.ThrowsException<ArgumentException>(() => ArgumentValidator.EnsureBetweenInclusive(9, "n", 10, 20));
 
@@ -124,11 +117,5 @@ namespace ArgumentValidatorTests
 
 		[TestMethod]
 		public void maximum_passes() => ArgumentValidator.EnsureBetweenInclusive(20, "n", 10, 20);
-
-		[TestMethod]
-		public void null_minimum_passes() => ArgumentValidator.EnsureBetweenInclusive("arg", "n", null, "max");
-
-		[TestMethod]
-		public void null_maximum_passes() => ArgumentValidator.EnsureBetweenInclusive("arg", "n", "min", null);
 	}
 }

--- a/_Tests/Dinah.Core.Tests/Dinah.Core.Tests.csproj
+++ b/_Tests/Dinah.Core.Tests/Dinah.Core.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/_Tests/Dinah.Core.Tests/EnumExtensionsTests.cs
+++ b/_Tests/Dinah.Core.Tests/EnumExtensionsTests.cs
@@ -15,29 +15,6 @@ using Newtonsoft.Json.Linq;
 
 namespace EnumExtensionsTests
 {
-	public struct NonEnum : IConvertible
-	{
-		#region non-implemented IConvertible methods
-		public TypeCode GetTypeCode() => throw new NotImplementedException();
-		public bool ToBoolean(IFormatProvider provider) => throw new NotImplementedException();
-		public byte ToByte(IFormatProvider provider) => throw new NotImplementedException();
-		public char ToChar(IFormatProvider provider) => throw new NotImplementedException();
-		public DateTime ToDateTime(IFormatProvider provider) => throw new NotImplementedException();
-		public decimal ToDecimal(IFormatProvider provider) => throw new NotImplementedException();
-		public double ToDouble(IFormatProvider provider) => throw new NotImplementedException();
-		public short ToInt16(IFormatProvider provider) => throw new NotImplementedException();
-		public int ToInt32(IFormatProvider provider) => throw new NotImplementedException();
-		public long ToInt64(IFormatProvider provider) => throw new NotImplementedException();
-		public sbyte ToSByte(IFormatProvider provider) => throw new NotImplementedException();
-		public float ToSingle(IFormatProvider provider) => throw new NotImplementedException();
-		public string ToString(IFormatProvider provider) => throw new NotImplementedException();
-		public object ToType(Type conversionType, IFormatProvider provider) => throw new NotImplementedException();
-		public ushort ToUInt16(IFormatProvider provider) => throw new NotImplementedException();
-		public uint ToUInt32(IFormatProvider provider) => throw new NotImplementedException();
-		public ulong ToUInt64(IFormatProvider provider) => throw new NotImplementedException();
-		#endregion
-	}
-
 	public enum ByteEnum : byte
 	{
 		None,
@@ -74,9 +51,6 @@ namespace EnumExtensionsTests
 	[TestClass]
 	public class ToValues
 	{
-		[TestMethod]
-		public void non_enum_throws()
-			=> Assert.ThrowsException<ArgumentException>(() => new NonEnum().ToValues().ToArray());
 
 		[TestMethod]
 		public void byte_enum_throws()

--- a/_Tests/TestCommon/JsonExamples.cs
+++ b/_Tests/TestCommon/JsonExamples.cs
@@ -1,18 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
-using Moq.Protected;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using TestCommon;
 
+#nullable enable
 namespace JsonExamples
 {
     [TestClass]
@@ -21,7 +15,7 @@ namespace JsonExamples
         public class JsonTest
         {
             [JsonProperty]
-            private string nullPriv;
+            private string? nullPriv;
 
             [JsonProperty]
             private int priv;
@@ -33,17 +27,17 @@ namespace JsonExamples
             public void setGPS(double gps) => GetPrivSet = gps;
 
             [JsonRequired]
-            private string privReq = "q";
-            public void SetPrivReq(string pr) => privReq = pr;
-            public string GetPrivReq() => privReq;
+            private string? privReq = "q";
+            public void SetPrivReq(string? pr) => privReq = pr;
+            public string? GetPrivReq() => privReq;
 
             [JsonProperty]
-            private ComplexType complexType;
+            private ComplexType? complexType;
             public void SetComplexType(ComplexType ct) => complexType = ct;
-            public ComplexType GetComplexType() => complexType;
+            public ComplexType? GetComplexType() => complexType;
 
             [JsonIgnore]
-            public string IgnoreMe { get; set; }
+            public string? IgnoreMe { get; set; }
 
             [JsonConstructor]
             private JsonTest(int getOnly) => GetOnly = getOnly;
@@ -54,7 +48,7 @@ namespace JsonExamples
         }
         public class ComplexType
         {
-            public string Value { get; set; }
+            public string? Value { get; set; }
             public DateTime Expires { get; set; }
         }
 
@@ -66,7 +60,7 @@ namespace JsonExamples
             public Guid Id { get; set; }
 
             [JsonProperty]
-            public string Name { get; set; }
+            public string? Name { get; set; }
 
             [JsonProperty]
             public int Size { get; set; }
@@ -79,7 +73,8 @@ namespace JsonExamples
             var ser = JsonConvert.SerializeObject(j);
             var deser = JsonConvert.DeserializeObject<JsonTest>(ser);
 
-            deser.GetOnly.Should().Be(9);
+			deser.Should().NotBeNull();
+			deser!.GetOnly.Should().Be(9);
         }
 
         [TestMethod]
@@ -98,7 +93,8 @@ namespace JsonExamples
             j.setPriv(2);
             var ser = JsonConvert.SerializeObject(j);
             var deser = JsonConvert.DeserializeObject<JsonTest>(ser);
-            deser.GetPriv().Should().Be(2);
+			deser.Should().NotBeNull();
+			deser!.GetPriv().Should().Be(2);
         }
 
         [TestMethod]
@@ -115,7 +111,8 @@ namespace JsonExamples
 
             // cannot be deserialized
             var deser = JsonConvert.DeserializeObject<JsonTest>(ser);
-            deser.GetPrivSet.Should().Be(default);
+			deser.Should().NotBeNull();
+			deser!.GetPrivSet.Should().Be(default);
         }
 
         [TestMethod]
@@ -127,7 +124,8 @@ namespace JsonExamples
 
             var ser = JsonConvert.SerializeObject(j);
             var deser = JsonConvert.DeserializeObject<JsonTest>(ser);
-            deser.GetPrivReq().Should().Be("y");
+			deser.Should().NotBeNull();
+			deser!.GetPrivReq().Should().Be("y");
         }
 
         [TestMethod]
@@ -146,14 +144,16 @@ namespace JsonExamples
 
             var ser = JsonConvert.SerializeObject(j);
             var deser = JsonConvert.DeserializeObject<JsonTest>(ser);
-            deser.GetComplexType().Should().BeNull();
+			deser.Should().NotBeNull();
+			deser!.GetComplexType().Should().BeNull();
 
             var token = new ComplexType { Value = "v", Expires = DateTime.MaxValue };
             deser.SetComplexType(token);
             var ser2 = JsonConvert.SerializeObject(deser);
             var deser2 = JsonConvert.DeserializeObject<JsonTest>(ser2);
-            deser2.GetComplexType().Value.Should().Be("v");
-            deser2.GetComplexType().Expires.Should().Be(DateTime.MaxValue);
+			deser2.Should().NotBeNull();
+			deser2!.GetComplexType()?.Value.Should().Be("v");
+            deser2.GetComplexType()?.Expires.Should().Be(DateTime.MaxValue);
         }
 
         [TestMethod]
@@ -166,7 +166,8 @@ namespace JsonExamples
             var ser = JsonConvert.SerializeObject(j);
             ser.Should().NotContain(nameof(j.IgnoreMe));
             var deser = JsonConvert.DeserializeObject<JsonTest>(ser);
-            deser.IgnoreMe.Should().BeNull();
+			deser.Should().NotBeNull();
+			deser!.IgnoreMe.Should().BeNull();
         }
 
         [TestMethod]
@@ -176,7 +177,8 @@ namespace JsonExamples
             var ser = JsonConvert.SerializeObject(o);
             ser.Should().NotContain(nameof(o.Id));
             var deser = JsonConvert.DeserializeObject<OptIn>(ser);
-            deser.Name.Should().Be("n");
+			deser.Should().NotBeNull();
+			deser!.Name.Should().Be("n");
             deser.Size.Should().Be(7);
             Assert.AreEqual(deser.Id, default);
         }
@@ -195,7 +197,7 @@ namespace JsonExamples
 		public void ctor_1_param()
 			=> JsonConvert
 				.DeserializeObject<_1Param>("{ \"bar\": \"hello\" }")
-				.Bar.Should().Be("hello");
+				?.Bar.Should().Be("hello");
 
 		public class _2Params
 		{
@@ -212,7 +214,8 @@ namespace JsonExamples
 		public void match_param_order_match_case()
 		{
 			var obj = JsonConvert.DeserializeObject<_2Params>("{ \"foo\":\"f\" , \"bar\":\"b\" }");
-			obj.Foo.Should().Be("f");
+			obj.Should().NotBeNull();
+			obj!.Foo.Should().Be("f");
 			obj.Bar.Should().Be("b");
 		}
 
@@ -220,7 +223,8 @@ namespace JsonExamples
 		public void match_param_order_not_match_case()
 		{
 			var obj = JsonConvert.DeserializeObject<_2Params>("{ \"FOO\":\"f\" , \"bAr\":\"b\" }");
-			obj.Foo.Should().Be("f");
+			obj.Should().NotBeNull();
+			obj!.Foo.Should().Be("f");
 			obj.Bar.Should().Be("b");
 		}
 
@@ -228,7 +232,8 @@ namespace JsonExamples
 		public void not_match_param_order_match_case()
 		{
 			var obj = JsonConvert.DeserializeObject<_2Params>("{ \"bar\":\"b\" , \"foo\":\"f\" }");
-			obj.Foo.Should().Be("f");
+			obj.Should().NotBeNull();
+			obj!.Foo.Should().Be("f");
 			obj.Bar.Should().Be("b");
 		}
 
@@ -236,7 +241,8 @@ namespace JsonExamples
 		public void not_match_param_order_not_match_case()
 		{
 			var obj = JsonConvert.DeserializeObject<_2Params>("{ \"bAR\":\"b\" , \"Foo\":\"f\" }");
-			obj.Foo.Should().Be("f");
+			obj.Should().NotBeNull();
+			obj!.Foo.Should().Be("f");
 			obj.Bar.Should().Be("b");
 		}
 	}
@@ -380,14 +386,14 @@ namespace JsonExamples
             var j = JObject.Parse(jObj);
 
             // direct cast
-            var _9 = (int)j["Id"];
+            var _9 = j["Id"]?.Value<int>();
             _9.Should().Be(9);
-            var rick = (string)j["Name"];
+            var rick = j["Name"]?.Value<string>();
             rick.Should().Be("Rick");
 
             // or with ToString
-            var westWind = j["Company"].ToString();
-            westWind.Should().Be("West Wind");
+            var westWind = j["Company"]?.Value<string>();
+			westWind.Should().Be("West Wind");
         }
 
         [TestMethod]
@@ -431,14 +437,14 @@ namespace JsonExamples
             var techGuys = JArray.Parse(json);
 
             // direct cast
-            var bill = (string)techGuys[0]["Name"];
+            var bill = techGuys[0]["Name"]?.Value<string>();
             bill.Should().Be("Bill");
-            var ms = (string)techGuys[0]["Company"];
-            ms.Should().Be("Microsoft");
+            var ms = techGuys[0]["Company"]?.Value<string>();
+			ms.Should().Be("Microsoft");
 
             // or ToString
-            techGuys[1]["Name"].ToString().Should().Be("Steve");
-            techGuys[1]["Company"].ToString().Should().Be("Apple");
+            techGuys[1]["Name"]?.Value<string>().Should().Be("Steve");
+            techGuys[1]["Company"]?.Value<string>().Should().Be("Apple");
         }
 
         [TestMethod]
@@ -484,8 +490,8 @@ namespace JsonExamples
 
             var cast = (JObject)token;
 
-            cast["Name"].ToString().Should().Be("Rick");
-            cast["Company"].ToString().Should().Be("West Wind");
+            cast["Name"]?.Value<string>().Should().Be("Rick");
+            cast["Company"]?.Value<string>().Should().Be("West Wind");
         }
 
         [TestMethod]
@@ -508,26 +514,26 @@ namespace JsonExamples
 
             var cast = (JArray)token;
 
-            cast[0]["Name"].ToString().Should().Be("Bill");
-            cast[0]["Company"].ToString().Should().Be("Microsoft");
-            cast[1]["Name"].ToString().Should().Be("Steve");
-            cast[1]["Company"].ToString().Should().Be("Apple");
+            cast[0]["Name"]?.Value<string>().Should().Be("Bill");
+            cast[0]["Company"]?.Value<string>().Should().Be("Microsoft");
+            cast[1]["Name"]?.Value<string>().Should().Be("Steve");
+            cast[1]["Company"]?.Value<string>().Should().Be("Apple");
         }
 
         // below examples adapted from:
         // https://weblog.west-wind.com/posts/2012/aug/30/using-jsonnet-for-dynamic-json-parsing
         public class Album
         {
-            public string AlbumName { get; set; }
-            public string Artist { get; set; }
+            public string? AlbumName { get; set; }
+            public string? Artist { get; set; }
             public int YearReleased { get; set; }
             public List<Song> Songs { get; set; } = new List<Song>();
         }
 
         public class Song
         {
-            public string SongName { get; set; }
-            public string SongLength { get; set; }
+            public string? SongName { get; set; }
+            public string? SongLength { get; set; }
         }
 
         [TestMethod]
@@ -572,10 +578,10 @@ namespace JsonExamples
             var jalbum = albums[0] as JObject;
 
             // Copy to a new Album instance
-            var album = jalbum.ToObject<Album>();
+            var album = jalbum?.ToObject<Album>();
 
             Assert.IsNotNull(album);
-            Assert.AreEqual(album.AlbumName, jalbum.Value<string>("AlbumName"));
+            Assert.AreEqual(album.AlbumName, jalbum?.Value<string>("AlbumName"));
             Assert.IsTrue(album.Songs.Count > 0);
         }
 

--- a/_Tests/TestCommon/TestCommon.csproj
+++ b/_Tests/TestCommon/TestCommon.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
I've been on a quest to enable nullable reference types. I found the best way to do this is to enable one file at a time so the warnings aren't as overwhelming.

I also changed a few things:

- Use the built-in .NET `HashCode` struct to generate hash codes
- Remove Enum `GetValues<T>` extensions. They're built-in to .NET
- Change enum generic constraints from `struct, IConvertible` to `struct, Enum`
- Change `EnsureGreaterThan` and `EnsureBetweenInclusive` generic constraints from `IComparable<T>` to `struct, INumber<T>`